### PR TITLE
Experiments/homepage-video

### DIFF
--- a/assets/scss/templates/_page-home.scss
+++ b/assets/scss/templates/_page-home.scss
@@ -6,6 +6,7 @@
   .page-home__screen-block--welcome {
     .bold-header {
       position: relative;
+      top: 220px;
       h1 {
         width: 80%;
         margin: auto;
@@ -22,6 +23,16 @@
       width: 45%;
       min-width: 280px;
       height: auto;
+      display: none;
+    }
+
+    .video-container {
+      height: 0;
+      margin-top: -330px;
+
+      video {
+        width: 100%;
+      }
     }
 
     .down-chevron {

--- a/source/templates/page-home.jsx
+++ b/source/templates/page-home.jsx
@@ -29,6 +29,12 @@ export default class PageHome extends React.Component {
       <article className="page-home">
         <ScreenBlock customClass="page-home__screen-block--welcome" colour="rain">
           <HeadlineBackground className="page-home__headline-background" src="images/home/Homepage-Hero.png"/>
+          <div className="video-container">
+            <video autoPlay loop>
+              <source src="videos/watches_test.mp4" type='video/mp4' />
+              <p>This is fallback content</p>
+            </video>
+          </div>
           <BoldHeader colour="white">We're a digital<br/>product studio</BoldHeader>
           <DownChevron ref="downChevron" onClick={this.animateChevron}/>
         </ScreenBlock>


### PR DESCRIPTION
@daaain DO NOT MERGE INTO MASTER!!!

This is just an experiment into the homepage video option. Adding it as a pull request for reviewing purposes.

Conclusions of the experiment are...
- ios does not support autoplay videos instead showing a play button which triggers full screen video mode
- purples in the video do not match the background and will not ever once we introduce the scrolling colour change
- alpha channels in videos are not supported except in Chrome 30+ with webm videos
- there exists a hack using canvas and masking for other html5 video supporting browsers but it has poor performance on mobile so we would need to device sniff rather than feature detect and have multiple layers of fallbacks!

For these reasons I would suggest not using video for the animation effects on the homepage.
