### PR TITLE
Remove CORS and Origin header

### DIFF
--- a/src/app/_lib/fetcher.js
+++ b/src/app/_lib/fetcher.js
@@ -9,10 +9,6 @@ import window from '../../server/adaptors/window';
 let ajaxes = {};
 
 let defaultConfig = {
-  mode: 'cors',
-  headers: {
-    'Origin': window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '')
-  },
   baseurl: require('../../server/adaptors/proxy-url')
 }
 


### PR DESCRIPTION
@ch2ch3 , @phil-linnell I've removed the CORS rules in `fetcher.js` as they are not required anymore.  Please test it before merging to `master`?
