### PR TITLE
Expose assets over HTTP to let the CDN consume them

### DIFF
--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -9,9 +9,35 @@ server {
   listen 80 default;
   server_name localhost ustwo.com www.ustwo.com www.ustwo.co.uk ustwo.co.uk;
 
-  # location /loaderio-c53e2e26b96a6dddadc98f41c54e1902.txt {
-  #   alias /usr/share/nginx/html/loaderio-c53e2e26b96a6dddadc98f41c54e1902.txt;
-  # }
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location = /robots.txt {
+    alias /usr/share/nginx/html/robots.txt;
+  }
+
+  location = /favicon.ico {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.ico;
+  }
+  location = /favicon.png {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.png;
+  }
+
+  location /images {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /css {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /js {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+
 
   location / {
     rewrite ^ https://$host$request_uri? permanent;

--- a/etc/nginx/conf.d/dev.conf
+++ b/etc/nginx/conf.d/dev.conf
@@ -7,14 +7,43 @@ upstream frontend {
 
 server {
   listen 80;
-  server_name localhost 2015.ustwo.com canary.ustwo.com;
+  server_name ustwo.com;
 
-  rewrite ^ https://$host:9443$request_uri? permanent;
+  location = /robots.txt {
+    alias /usr/share/nginx/html/robots.txt;
+  }
+
+  location = /favicon.ico {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.ico;
+  }
+  location = /favicon.png {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.png;
+  }
+
+  location /images {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /css {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /js {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+
+  location / {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
 }
 
 server {
   listen 443 ssl spdy;
-  server_name localhost 2015.ustwo.com canary.ustwo.com;
+  server_name ustwo.com;
+
   include /etc/nginx/ssl.conf;
 
   root /usr/share/nginx/html;

--- a/etc/nginx/conf.d/staging.conf
+++ b/etc/nginx/conf.d/staging.conf
@@ -9,7 +9,38 @@ server {
   listen 80;
   server_name localhost 2015.ustwo.com canary.ustwo.com;
 
-  rewrite ^ https://$host$request_uri? permanent;
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location = /robots.txt {
+    alias /usr/share/nginx/html/robots.txt;
+  }
+
+  location = /favicon.ico {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.ico;
+  }
+  location = /favicon.png {
+    expires modified +24h;
+    alias /usr/share/nginx/assets/favicon.png;
+  }
+
+  location /images {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /css {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+  location /js {
+    expires modified +24h;
+    root /usr/share/nginx/assets;
+  }
+
+  location / {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
 }
 
 server {


### PR DESCRIPTION
@phil-linnell @ch2ch3 assets exposed over HTTP given the CDN restriction with SSL consumption.

Test:
- `http://local.ustwo.com:9080/js/app.js` (dev)
- `http://2015.ustwo.com/js/app.js` (staging)
