### PR TITLE
Add confirmation to make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ test: assets-test
 push: app-push assets-push
 pull: app-pull assets-pull
 init: vault-create assets-create app-create proxy-create
-clean: proxy-rm app-rm assets-rm vault-rm
-deploy: clean init
+rm-all: proxy-rm app-rm assets-rm vault-rm
+clean:
+	$(call confirm,"Are you sure you want to clean __$(DOCKER_MACHINE_NAME)__?",$(MAKE) -i rm-all)
+deploy: rm-all init
 deploy-production:
 	$(MAKE) -i deploy \
 		PROXY_HTTPS_PORT=443 \
@@ -71,16 +73,13 @@ deploy-staging: deploy-production
 release: release-create
 
 seeds: build
-love: clean init
+love: rm-all init
 stuff: assets-compile
 css: assets-css
 css-watch: assets-css-watch
 vendors: assets-vendors
 spa: assets-spa
 images: assets-images
-
-## Obsolete ###################################################################
-init-rm: clean
 
 ## Environment  ###############################################################
 ##
@@ -114,3 +113,5 @@ absorb:
 	git pull --rebase=preserve origin master
 	git checkout $(GIT_BRANCH)
 	git rebase master
+
+

--- a/tasks/lib.mk
+++ b/tasks/lib.mk
@@ -70,6 +70,23 @@ define abort
 	@echo $1
 	@exit 1
 endef
+##
+# Prompts with a y/n question and reacts on the answer
+#
+# $1 - Question
+# $2 - Action
+#
+# Example:
+#
+#     $(call confirm,"Wanna dance?",make dance)
+define confirm
+	@echo $1 [y/n]
+	@read -e ANSWER; \
+	case $$ANSWER in \
+		[Yy]) $2;; \
+		*) echo "Action cancelled";exit 0;; \
+	esac
+endef
 
 define warn
 	@echo "*********************************************************************"


### PR DESCRIPTION
@davidey @collingo @daaain This PR adds a confirmation action when doing `make clean` so it would prevent cleaning production.

To check it:

``` sh
make -i love
make clean
```
- Verify that y/n do the job
- Verify that the current docker-machine environment is correct in the prompt.
