### PR TITLE
Docs/vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public/*
 etc/nginx/ssl
 share/nginx/assets
 build
+sensitive

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GREP := grep
 MKDIR := mkdir -p
 FSWATCH := fswatch
 RM := rm -rf
+MV := mv
 XARGS := xargs
 DOCKER := docker
 DOCKER_CP := $(DOCKER) cp

--- a/README.md
+++ b/README.md
@@ -147,14 +147,31 @@ you want (like Docker Toolbox / [Kitematic][7]).
 *Note*: The IP number above depends on your local instance. Check
 `docker-machine ip dev`.
 
+
 ### Credentials / Vault
 
-TODO: steps how to run local instance with self certification.
+If you receive the image tar from someone in the team just do:
 
-* Get the vault from someone (e.g. arnau@ustwo.com) and load it in your
-docker environment.
+        $ make vault-load VAULT_PATH=path/to/vault-2015.tar
 
-        $ make vault-load VAULT_PATH=vault-2015.tar
+*If not*, put your SSL certificates in the project's `etc/nginx/ssl` using
+`usweb` as the filename:
+
+    $ ls etc/nginx/ssl
+    ustwo.com.chained.cert  ustwo.com.key
+
+Optionally you can create a self-signed certificate via:
+
+    $ make vault-generate-cert
+
+Then build the vault image:
+
+    $ make vault-build
+
+*Note*: If you use self-signed certificates you probably want to use your
+docker IP (e.g. `docker-machine ip dev`) instead of a custom `ustwo.com`
+domain.
+
 
 ## Develop
 

--- a/tasks/vault.mk
+++ b/tasks/vault.mk
@@ -32,9 +32,15 @@ build/vault-$(vault_version).tar: vault-build
 
 vault-save: build/vault-$(vault_version).tar
 
-# Imports the vault tarball into the docker environment.
-load-vault: build/vault-$(vault_version).tar
-	$(DOCKER) load -i $<
-
 vault-load:
 	$(DOCKER) load -i $(VAULT_PATH)
+
+# TODO: Normalise cert name to usweb.
+vault-generate-cert:
+	@$(DOCKER_TASK) \
+		-e COMMON_NAME=$(project_name) \
+		-e KEY_NAME=$(project_name) \
+		-v $(PWD)/etc/nginx/ssl:/certs \
+		centurylink/openssl
+	@$(MV) $(PWD)/etc/nginx/ssl/usweb.crt $(PWD)/etc/nginx/ssl/ustwo.com.chained.cert
+	@$(MV) $(PWD)/etc/nginx/ssl/usweb.key $(PWD)/etc/nginx/ssl/ustwo.com.key


### PR DESCRIPTION
@phil-linnell @daaain @ch2ch3 @petronbot please take a look at this PR.  It explains how to create the vault yourself and provides a make task to create the self-signed SSL certificate.

The README should be enough to review the PR.

*IMPORTANT* If you create self-signed certificate you probably want to keep the vault-2015.tar file I shared with you at some point so you can later on use `make vault-load VAULT_PATH=path/to/vault-2015.tar` to put our SSL cert back.