### PR TITLE
Add missing alias for Track from Flux

### DIFF
--- a/src/app/aliases.json
+++ b/src/app/aliases.json
@@ -9,6 +9,7 @@
     "../../adaptors/server/scroll-to-plugin": "./adaptors/client/scroll-to-plugin",
     "../adaptors/server/scroll-tracker": "./adaptors/client/scroll-tracker",
     "../../adaptors/server/svg4everybody": "./adaptors/client/svg4everybody",
+    "../adaptors/server/track": "./adaptors/client/track",
     "../../adaptors/server/track": "./adaptors/client/track",
     "../adaptors/server/tracking": "./adaptors/client/tracking",
     "../../adaptors/server/tracking": "./adaptors/client/tracking",


### PR DESCRIPTION
@daaain @arnau 

The server adaptor for Track wasn't getting replaced with `ga` :)

This raises another question for me: we're only sending page views from within Flux, and so not accommodating users who have JS turned off. Thoughts?

(fixes #224)