### PR TITLE
Extract docker0 interface to DOCKER0_INTERFACE

### DIFF
--- a/tasks/lib.mk
+++ b/tasks/lib.mk
@@ -8,8 +8,9 @@ endif
 
 # this is passed on to the server side React renderer to be able to reach the proxy
 DOCKER_PROXY_HOST ?= docker.ustwo.com
+DOCKER0_INTERFACE ?= 172.17.42.1
 define docker_host
---add-host $(DOCKER_PROXY_HOST):172.17.42.1
+--add-host $(DOCKER_PROXY_HOST):$(DOCKER0_INTERFACE)
 endef
 
 define project_labels


### PR DESCRIPTION
@collingo @ustwo/usweb-dev this PR extracts the `docker0` IP to `DOCKER0_INTERFACE` so it can be customised.

The problem:  Users using Docker 1.9  (@davidey, me) cannot work with the docker0 hack as the `docker0` ip changed.

The solution: Meanwhile we don't migrate to proper networking and move everyone to 1.9, we will customise `DOCKER0_INTERFACE` for whomever runs 1.9.

To test it:

1.8 users:  `make -i love` and check everything works correctly in the browser.
1.9 users: `export DOCKER0_INTERFACE=172.17.0.1` (in your `.bash_profile` or similar) and run `make -i love`.  check it works in the browser.