### PR TITLE
Features/stronger networking

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -6,4 +6,6 @@ RUN npm install --production
 COPY src /home/ustwo/src
 RUN mkdir -p /home/ustwo/public
 
+EXPOSE 8888
+
 CMD ["node", "./node_modules/babel/lib/_babel-node", "--optional", "es7.classProperties", "src/server"]

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -6,4 +6,6 @@ RUN npm install --production
 COPY src /home/ustwo/src
 RUN mkdir -p /home/ustwo/public
 
+EXPOSE 8889
+
 CMD ["node", "./node_modules/babel/lib/_babel-node", "--optional", "es7.classProperties", "src/server/index.sandbox.js"]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DOCKER_CP := $(DOCKER) cp
 DOCKER_EXEC := $(DOCKER) exec -it
 DOCKER_RM := $(DOCKER) rm -vf
 DOCKER_PROC := $(DOCKER) run -d
-DOCKER_VOLUME := $(DOCKER) run
+DOCKER_VOLUME := $(DOCKER) create
 DOCKER_TASK := $(DOCKER) run --rm -it
 # CircleCI fails if you try to remove a container
 DOCKER_CI_TASK := $(DOCKER) run -it

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ ANSIBLE_PLAY := $(ANSIBLE) ansible-playbook -b -v \
 	--inventory-file=/home/ustwo/etc/ansible/hosts
 ###############################################################################
 
+default: build-all
+
 include tasks/*.mk
 
 ## Automatic variables ########################################################
@@ -60,9 +62,8 @@ include tasks/*.mk
 ###############################################################################
 
 ## Porcelain ##################################################################
-default: compiler-build build
 install: network-create vault-create assets-create app-create proxy-create
-
+build-all: compiler-build build
 vault: vault-save
 build: app-build assets-build
 test: assets-unit-test assets-integration-test

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ ANSIBLE_PLAY := $(ANSIBLE) ansible-playbook -b -v \
 	--inventory-file=/home/ustwo/etc/ansible/hosts
 ###############################################################################
 
-default: compiler-build build
-install: init
-
 include tasks/*.mk
 
 ## Automatic variables ########################################################
@@ -63,18 +60,20 @@ include tasks/*.mk
 ###############################################################################
 
 ## Porcelain ##################################################################
+default: compiler-build build
+install: network-create vault-create assets-create app-create proxy-create
+
 vault: vault-save
 build: app-build assets-build
 test: assets-unit-test assets-integration-test
 push: app-push assets-push
 pull: app-pull assets-pull
-init: network-create vault-create assets-create app-create proxy-create
 clean-no-confirm:
 	@$(DOCKER_RM) $(shell $(DOCKER) ps -aq $(project_filters))
 	@$(MAKE) network-rm
 clean:
 	$(call confirm,"Are you sure you want to clean __$(DOCKER_MACHINE_NAME)__?",$(MAKE) -i clean-no-confirm)
-deploy: clean-no-confirm init
+deploy: clean-no-confirm install
 deploy-production:
 	$(MAKE) -i deploy \
 		PROXY_HTTPS_PORT=443 \
@@ -93,6 +92,8 @@ images: assets-images
 
 sandbox: sandbox-rm sandbox-create
 
+## Deprecated  ################################################################
+init: install
 ## Environment  ###############################################################
 ##
 # Lists all containers related to the project.

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,10 @@ build: app-build assets-build
 test: assets-unit-test assets-integration-test
 push: app-push assets-push
 pull: app-pull assets-pull
-init: vault-create assets-create app-create proxy-create
+init: network-create vault-create assets-create app-create proxy-create
 clean-no-confirm:
 	@$(DOCKER_RM) $(shell $(DOCKER) ps -aq $(project_filters))
+	@$(MAKE) network-rm
 clean:
 	$(call confirm,"Are you sure you want to clean __$(DOCKER_MACHINE_NAME)__?",$(MAKE) -i clean-no-confirm)
 deploy: clean-no-confirm init

--- a/circle.yml
+++ b/circle.yml
@@ -16,11 +16,7 @@ deployment:
 
 dependencies:
   override:
-    # - make compiler-build
-    # - make assets-build
-    # - make app-build
-    # - make vault-generate-cert
-    # - make vault-build
+    - make vault-generate-cert vault-build
     - make
     - make install
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,17 +12,17 @@ deployment:
     branch: /(master|hotfixes\/.+)/
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - make app-push assets-push
+      - make push
 
 dependencies:
   override:
-    - docker version
-    - make compiler-build
-    - make assets-build
-    - make app-build
-    - make vault-generate-cert
-    - make vault-build
-    - make init
+    # - make compiler-build
+    # - make assets-build
+    # - make app-build
+    # - make vault-generate-cert
+    # - make vault-build
+    - make
+    - make install
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   environment:
     VERSION: $CIRCLE_SHA1
+  pre:
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
+    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -7,12 +7,12 @@ upstream backend {
 }
 
 upstream frontend {
-  server docker.ustwo.com:8888;
+  server usweb_app:8888;
 }
 
-upstream sandbox {
-  server docker.ustwo.com:8889;
-}
+#upstream sandbox {
+#  server usweb_sandbox:8889 max_fails=1;
+#}
 
 
 ###############################################################################

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -23,7 +23,7 @@ upstream frontend {
 # TODO: refactor so we're not repeating includes
 server {
   listen 80;
-  server_name origin.ustwo.com;
+  server_name origin.ustwo.com usweb_proxy;
 
   include /etc/nginx/locations/production.conf;
 }

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -11,7 +11,7 @@ upstream frontend {
 }
 
 #upstream sandbox {
-#  server usweb_sandbox:8889 max_fails=1;
+#  server usweb_sandbox:8889;
 #}
 
 

--- a/etc/nginx/locations/production.conf
+++ b/etc/nginx/locations/production.conf
@@ -8,7 +8,7 @@ include /etc/nginx/locations/sitemap.conf;
 include /etc/nginx/locations/twitter.conf;
 include /etc/nginx/locations/spa.conf;
 include /etc/nginx/locations/api.conf;
-include /etc/nginx/locations/sandbox.conf;
+#include /etc/nginx/locations/sandbox.conf;
 
 location @spa {
   proxy_pass http://frontend;

--- a/etc/nginx/locations/staging.conf
+++ b/etc/nginx/locations/staging.conf
@@ -3,7 +3,7 @@ include /etc/nginx/locations/sitemap.conf;
 
 include /etc/nginx/locations/twitter.conf;
 include /etc/nginx/locations/spa.conf;
-include /etc/nginx/locations/sandbox.conf;
+#include /etc/nginx/locations/sandbox.conf;
 
 location /api {
   proxy_cache_methods GET;

--- a/tasks/app.mk
+++ b/tasks/app.mk
@@ -39,8 +39,7 @@ app-create:
 		$(app_volumes) \
 		--restart always \
 		$(project_labels) \
-		-p 8888:8888 \
-		$(docker_host) \
+		--net=$(network_name) \
 		-e PROXY_HTTPS_PORT=$(PROXY_HTTPS_PORT) \
 		-e DOCKER_PROXY_HOST=$(DOCKER_PROXY_HOST) \
 		$(verbose_flag) \

--- a/tasks/assets.mk
+++ b/tasks/assets.mk
@@ -81,5 +81,7 @@ assets-spa:
 assets-unit-test:
 	@$(call compile, npm test)
 
+
+assets-integration-test: INTEGRATION = true
 assets-integration-test: sauce-startup
 	@$(call compile, npm run integration $(subst /,-,"$(USER)-$(CIRCLE_BRANCH)"))

--- a/tasks/compiler.mk
+++ b/tasks/compiler.mk
@@ -25,6 +25,7 @@ define compile
 		$(verbose_flag) \
 		$(cache_flag) \
 		$(compiler_network) \
+		-e PROXY_NAME=$(proxy_name) \
 		-e SAUCE_USERNAME=$(SAUCE_USERNAME) \
 		-e SAUCE_ACCESS_KEY=$(SAUCE_ACCESS_KEY) \
 		$(compiler_image) $1

--- a/tasks/compiler.mk
+++ b/tasks/compiler.mk
@@ -15,11 +15,16 @@ compiler_volumes = \
   -v $(BASE_PATH)/test:/home/ustwo/test \
   -v $(BASE_PATH)/src:/home/ustwo/src
 
+# The compiler needs to be part of the shared network **only** when running
+# integration tests.
+compiler_network = $(if $(INTEGRATION),--net=$(network_name),)
+
 define compile
 	$(if $(CI), $(DOCKER_CI_TASK), $(DOCKER_TASK)) \
 		$(compiler_volumes) \
 		$(verbose_flag) \
 		$(cache_flag) \
+		$(compiler_network) \
 		-e SAUCE_USERNAME=$(SAUCE_USERNAME) \
 		-e SAUCE_ACCESS_KEY=$(SAUCE_ACCESS_KEY) \
 		$(compiler_image) $1

--- a/tasks/lib.mk
+++ b/tasks/lib.mk
@@ -6,13 +6,6 @@ ifeq ("$(FLUSH_CACHE)", "true")
   cache_flag = -e FLUSH_CACHE=true
 endif
 
-# this is passed on to the server side React renderer to be able to reach the proxy
-DOCKER_PROXY_HOST ?= docker.ustwo.com
-DOCKER0_INTERFACE ?= 172.17.42.1
-define docker_host
---add-host $(DOCKER_PROXY_HOST):$(DOCKER0_INTERFACE)
-endef
-
 define project_labels
 --label project_name=$(project_name) \
 --label version=$(VERSION)

--- a/tasks/network.mk
+++ b/tasks/network.mk
@@ -1,0 +1,15 @@
+## Network tasks ##############################################################
+network_name = usweb
+
+# WARNING: in test
+# net-install: net-create-app app-create
+net-install:
+	$(DOCKER) network connect $(network_name) $(proxy_name)
+
+
+net-create-app:
+	$(DOCKER) network create $(network_name)
+
+
+net-ls:
+	@$(DOCKER) network ls

--- a/tasks/network.mk
+++ b/tasks/network.mk
@@ -1,15 +1,16 @@
 ## Network tasks ##############################################################
 network_name = usweb
 
-# WARNING: in test
-# net-install: net-create-app app-create
-net-install:
-	$(DOCKER) network connect $(network_name) $(proxy_name)
+.PHONY: \
+  network-create \
+  network-rm \
+  network-ls
 
+network-create:
+	@$(DOCKER) network create $(network_name)
 
-net-create-app:
-	$(DOCKER) network create $(network_name)
+network-rm:
+	@$(DOCKER) network rm $(network_name)
 
-
-net-ls:
+network-ls:
 	@$(DOCKER) network ls

--- a/tasks/proxy.mk
+++ b/tasks/proxy.mk
@@ -23,9 +23,12 @@ proxy-create:
 		--name $(proxy_name) \
 		-p $(PROXY_HTTPS_PORT):443 \
 		-p $(PROXY_HTTP_PORT):80 \
-		$(docker_host) \
+		--net=$(network_name) \
 		--volumes-from $(vault_name) \
 		--volumes-from $(assets_name) \
 		--restart always \
 		$(project_labels) \
 		$(proxy_image)
+
+proxy-sh:
+	$(DOCKER_EXEC) $(proxy_name) /bin/sh

--- a/tasks/sandbox.mk
+++ b/tasks/sandbox.mk
@@ -39,8 +39,7 @@ sandbox-create:
 		$(sandbox_volumes) \
 		--restart always \
 		$(project_labels) \
-		-p 8889:8889 \
-		$(docker_host) \
+		--net=$(network_name) \
 		$(verbose_flag) \
 		$(sandbox_image)
 

--- a/tasks/sauce.mk
+++ b/tasks/sauce.mk
@@ -26,7 +26,6 @@ sauce-create:
 		--name $(sauce_name) \
 		-p 8000:8000 \
 		--net=$(network_name) \
-		-e PROXY_NAME=$(proxy_name) \
 		ustwo/docker-sauce-connect \
 		./bin/sc -P 8000 -u $(SAUCE_USERNAME) -k $(SAUCE_ACCESS_KEY) --tunnel-identifier $(subst /,-,"$(USER)-$(CIRCLE_BRANCH)") $(if $(CI),,--no-ssl-bump-domains *.ustwo.com)
 	@$(call wait_for_sauce)

--- a/tasks/sauce.mk
+++ b/tasks/sauce.mk
@@ -25,6 +25,7 @@ sauce-create:
 	@$(DOCKER) run -d \
 		--name $(sauce_name) \
 		-p 8000:8000 \
+		--net $(network_name) \
 		--link $(proxy_name):local.ustwo.com \
 		ustwo/docker-sauce-connect \
 		./bin/sc -P 8000 -u $(SAUCE_USERNAME) -k $(SAUCE_ACCESS_KEY) --tunnel-identifier $(subst /,-,"$(USER)-$(CIRCLE_BRANCH)") $(if $(CI),,--no-ssl-bump-domains *.ustwo.com)

--- a/tasks/sauce.mk
+++ b/tasks/sauce.mk
@@ -25,8 +25,8 @@ sauce-create:
 	@$(DOCKER) run -d \
 		--name $(sauce_name) \
 		-p 8000:8000 \
-		--net $(network_name) \
-		--link $(proxy_name):local.ustwo.com \
+		--net=$(network_name) \
+		-e PROXY_NAME=$(proxy_name) \
 		ustwo/docker-sauce-connect \
 		./bin/sc -P 8000 -u $(SAUCE_USERNAME) -k $(SAUCE_ACCESS_KEY) --tunnel-identifier $(subst /,-,"$(USER)-$(CIRCLE_BRANCH)") $(if $(CI),,--no-ssl-bump-domains *.ustwo.com)
 	@$(call wait_for_sauce)

--- a/tasks/sauce.mk
+++ b/tasks/sauce.mk
@@ -56,3 +56,5 @@ endif
 sauce-log:
 	@$(DOCKER) logs -f $(sauce_name)
 
+sauce-sh:
+	$(DOCKER_EXEC) $(sauce_name) /bin/sh

--- a/tasks/sync.mk
+++ b/tasks/sync.mk
@@ -22,9 +22,9 @@ sync-create:
 		-w /home/ustwo \
 		$(project_labels) \
 		--name $(sync_name) \
-		$(docker_host) \
 		$(sync_image) \
-		start --proxy "https://docker.ustwo.com:$(PROXY_HTTPS_PORT)" \
+		--net $(network_name) \
+		start --proxy "https://$(proxy_name):$(PROXY_HTTPS_PORT)" \
 					--files "share/nginx/assets/css/*.css" \
 					--port $(SYNC_PORT) \
 					--ui-port $(SYNC_ADMIN_PORT) \

--- a/test/integration/sanity.js
+++ b/test/integration/sanity.js
@@ -51,6 +51,7 @@ wd.configureHttp( {
 
 // building desired capability
 const browserKey = process.env.BROWSER || 'explorer';
+const proxyName = process.env.PROXY_NAME;
 let desired = desireds[browserKey];
 desired.name = 'testing with ' + browserKey;
 desired.tags = ['integration'];
@@ -61,7 +62,7 @@ const navigation = '.navigation';
 const navigationToggle = navigation + ' .navigation-toggle';
 const navigationOverlay = '.navigation-overlay';
 const navigationDesktopMenu = navigation + ' .menu';
-const baseURL = 'https://local.ustwo.com';
+const baseURL = 'http://' + proxyName;
 const homeTitle = 'ustwo | Digital product studio';
 const takeover = '.takeover';
 const takeoverClose = '.take-over .close-button';


### PR DESCRIPTION
@ustwo/usweb-dev @collingo This branch removes the old `docker0` trick and uses proper docker networking (available since Docker 1.9).

**REMEMBER** Upgrading to Docker 1.9 has consequences.  Make sure everyone in the team is ready to move forward before going ahead.

**UPDATE** CircleCI does not run Docker 1.9 by default so ci is broken in this branch until further notice.
This branch also disables the sandbox as nginx expects usweb_sandbox to be available within a reasonable time.

To test it:

* Upgrade to Docker 1.9
* Upgrade your docker-machine environment
* Build all the things `make build`
* Deploy: `make -i love`

The test is a success if accessing the website works.