### PR TITLE
Fix instances where data is being read from this.props.page instead of this.props.post

### DIFF
--- a/src/app/components/post/index.js
+++ b/src/app/components/post/index.js
@@ -65,19 +65,19 @@ const PagePost = React.createClass({
     return relatedContent;
   },
   renderSocialMediaSharing(position) {
-    const props = this.props;
+    const { post, facebookShares, twitterShares } = this.props;
     return (
       <SocialMediaSharing
         className={position}
-        title={he.decode(get(props.post, 'title.rendered', ''))}
-        uri={`http://ustwo.com/blog/${get(props.page, 'slug')}`}
-        facebookShares={props.facebookShares}
-        twitterShares={props.twitterShares}
+        title={he.decode(get(post, 'title.rendered', ''))}
+        uri={`http://ustwo.com/blog/${get(post, 'slug')}`}
+        facebookShares={facebookShares}
+        twitterShares={twitterShares}
       />
     );
   },
   renderAuthorInformation() {
-    const { page: post } = this.props;
+    const { post } = this.props;
     const author = get(post, '_embedded.author.0');
     return <section className='author'>
       <img


### PR DESCRIPTION
Hey @ustwo/usweb-dev @collingo I couldn't test this with my outdated setup, but this should fix "http://ustwo.com/blog/undefined" when sharing a blog post, and author information not showing up.