### PR TITLE
Add hash support for join us locations

### DIFF
--- a/src/app/components/join-us/index.js
+++ b/src/app/components/join-us/index.js
@@ -21,13 +21,13 @@ import StudioJobs from 'app/components/studio-jobs';
 import Rimage from 'app/components/rimage';
 import Video from 'app/components/video';
 
-function isSelected(currentSection, id, studios) {
+function isSelected(currentHash, id, studios) {
   const studioNames = pluck(studios, 'name');
   let selected = false;
   if(
-    (!currentSection && id === 'all-studios')
-    || currentSection && id === 'all-studios' && every(studioNames, name => currentSection !== kebabCase(name))
-    || currentSection && currentSection === id
+    (!currentHash && id === 'all-studios')
+    || currentHash && id === 'all-studios' && every(studioNames, name => currentHash !== kebabCase(name))
+    || currentHash && currentHash === id
   ) {
     selected = true;
   }
@@ -69,22 +69,22 @@ const PageJoinUs = React.createClass({
     }].concat(this.props.studios);
   },
   renderStudioTabs() {
+    const { currentParams } = this.props;
     return map(this.getStudios(), studio => {
-      const id = kebabCase(studio.name);
-      const name = spannify(studio.name);
+      const studioId = kebabCase(studio.name);
+      const studioName = spannify(studio.name);
       return <li
-        key={`tab-${id}`}
-        className={id}
-        ref={`tab-${id}`}
-        onClick={this.generateOnClickStudioHandler(id)}
-        aria-selected={isSelected(this.props.currentSection, id, this.props.studios)}
-      >{name}</li>;
+        key={`tab-${studioId}`}
+        className={studioId}
+        onClick={this.generateOnClickStudioHandler(studioId)}
+        aria-selected={isSelected(get(currentParams, 'lid'), studioId, this.props.studios)}
+      >{studioName}</li>;
     });
   },
   generateOnClickStudioHandler(studio) {
     return () => {
-      const hash = studio !== 'all-studios' ? '#'+studio : '';
-      Flux.navigate(`/join-us${hash}`, true);
+      const uri = studio !== 'all-studios' ? '/'+studio : '';
+      Flux.navigate(`/join-us${uri}`, true);
     }
   },
   renderJobSection() {
@@ -108,15 +108,15 @@ const PageJoinUs = React.createClass({
     </div>;
   },
   renderStudioJobs() {
+    const { currentParams } = this.props;
     return map(this.getStudios(), studio => {
-      const { currentSection } = this.props;
-      const id = kebabCase(studio.name);
+      const studioId = kebabCase(studio.name);
       return <StudioJobs
-        key={`jobs-${id}`}
+        key={`jobs-${studioId}`}
         studio={studio}
         studios={this.props.studios}
         jobs={this.getJobsForStudio(studio)}
-        selected={isSelected(currentSection, id, this.props.studios)}
+        selected={isSelected(get(currentParams, 'lid'), studioId, this.props.studios)}
         contactEmail={get(find(get(find(get(this.props, 'footer.contacts', []), 'type', 'general'), 'methods', []), 'type', 'email'), 'uri', '')}
       />;
     });

--- a/src/app/components/join-us/index.js
+++ b/src/app/components/join-us/index.js
@@ -79,7 +79,7 @@ const PageJoinUs = React.createClass({
         key={`tab-${studioId}`}
         className={studioId}
         aria-selected={isSelected(get(currentParams, 'lid'), studioId, this.props.studios)}
-      ><a href={uri} onClick={Flux.override(uri)}>{studioName}</a></li>;
+      ><a href={uri} onClick={Flux.overrideNoScroll(uri)}>{studioName}</a></li>;
     });
   },
   generateStudioUri(studio) {

--- a/src/app/components/join-us/index.js
+++ b/src/app/components/join-us/index.js
@@ -99,9 +99,6 @@ const PageJoinUs = React.createClass({
             {this.renderStudioJobs(selectedStudioSlug)}
           </div>
         </section>
-        <div className="benefits">
-          <h2>Some of the benefits...</h2>
-        </div>
       </div>;
     };
   },

--- a/src/app/components/join-us/index.js
+++ b/src/app/components/join-us/index.js
@@ -20,6 +20,7 @@ import Hero from 'app/components/hero';
 import StudioJobs from 'app/components/studio-jobs';
 import Rimage from 'app/components/rimage';
 import Video from 'app/components/video';
+import Flux from 'app/flux';
 
 function isSelected(currentHash, id, studios) {
   const studioNames = pluck(studios, 'name');
@@ -73,19 +74,17 @@ const PageJoinUs = React.createClass({
     return map(this.getStudios(), studio => {
       const studioId = kebabCase(studio.name);
       const studioName = spannify(studio.name);
+      const uri = this.generateStudioUri(studioId);
       return <li
         key={`tab-${studioId}`}
         className={studioId}
-        onClick={this.generateOnClickStudioHandler(studioId)}
         aria-selected={isSelected(get(currentParams, 'lid'), studioId, this.props.studios)}
-      >{studioName}</li>;
+      ><a href={uri} onClick={Flux.override(uri)}>{studioName}</a></li>;
     });
   },
-  generateOnClickStudioHandler(studio) {
-    return () => {
-      const uri = studio !== 'all-studios' ? '/'+studio : '';
-      Flux.navigate(`/join-us${uri}`, true);
-    }
+  generateStudioUri(studio) {
+    const uri = studio !== 'all-studios' ? '/'+studio : '';
+    return `/join-us${uri}`;
   },
   renderJobSection() {
     const sizes = { hardcoded: { url: '/images/joinus/current_openings.jpg' }};

--- a/src/app/flux/actions.js
+++ b/src/app/flux/actions.js
@@ -1,8 +1,8 @@
 import Store from './store';
 
 const Actions = {
-  goTo(page, section, statusCode) {
-    Store.setPage(page, section, statusCode);
+  goTo(page, params, hash, statusCode) {
+    Store.setPage(page, params, hash, statusCode);
   },
   loadData(itemsToLoad) {
     Store.loadData(itemsToLoad || []);

--- a/src/app/flux/actions.js
+++ b/src/app/flux/actions.js
@@ -1,8 +1,8 @@
 import Store from './store';
 
 const Actions = {
-  goTo(pageId, statusCode) {
-    Store.setPage(pageId, statusCode);
+  goTo(page, section, statusCode) {
+    Store.setPage(page, section, statusCode);
   },
   loadData(itemsToLoad) {
     Store.loadData(itemsToLoad || []);

--- a/src/app/flux/index.js
+++ b/src/app/flux/index.js
@@ -99,6 +99,12 @@ const Flux = Object.assign(
         e.preventDefault();
         Flux.navigate(url);
       };
+    },
+    overrideNoScroll(url) {
+      return (e) => {
+        e.preventDefault();
+        Flux.navigate(url, true);
+      };
     }
   }
 );

--- a/src/app/flux/nulls.js
+++ b/src/app/flux/nulls.js
@@ -1,6 +1,7 @@
 export default {
   page: null,
-  section: null,
+  params: null,
+  hash: null,
   searchQuery: null,
   modal: null,
   takeover: null,

--- a/src/app/flux/nulls.js
+++ b/src/app/flux/nulls.js
@@ -1,5 +1,6 @@
 export default {
   page: null,
+  section: null,
   searchQuery: null,
   modal: null,
   takeover: null,

--- a/src/app/flux/routes.js
+++ b/src/app/flux/routes.js
@@ -9,7 +9,7 @@
 const routes = {
   home: {
     id: 'home',
-    pattern: '/',
+    patterns: ['/'],
     data: () => [{
       url: 'ustwo/v1/pages/home',
       type: 'page',
@@ -19,7 +19,7 @@ const routes = {
   },
   work: {
     id: 'what-we-do',
-    pattern: '/what-we-do',
+    patterns: ['/what-we-do'],
     data: () => [{
       url: 'ustwo/v1/pages/what-we-do',
       type: 'page',
@@ -28,7 +28,7 @@ const routes = {
   },
   caseStudy: {
     id: 'what-we-do/case-study',
-    pattern: '/what-we-do/:cid',
+    patterns: ['/what-we-do/:cid'],
     data: slug => [{
       url: `ustwo/v1/case-studies/${slug}`,
       type: 'caseStudy',
@@ -38,7 +38,7 @@ const routes = {
   },
   blogCategory: {
     id: 'blog',
-    pattern: '/blog?category=:category',
+    patterns: ['/blog?category=:category'],
     data: category => [{
       url: `ustwo/v1/pages/blog`,
       type: 'page',
@@ -51,7 +51,7 @@ const routes = {
   },
   blog: {
     id: 'blog',
-    pattern: '/blog',
+    patterns: ['/blog'],
     data: () => [{
       url: 'ustwo/v1/pages/blog',
       type: 'page',
@@ -64,7 +64,7 @@ const routes = {
   },
   searchResults: {
     id: 'blog/search-results',
-    pattern: '/blog/search?q=:query',
+    pattern: ['/blog/search?q=:query'],
     data: query => [{
       url: `ustwo/v1/posts?search=${query}`,
       type: 'posts',
@@ -73,7 +73,7 @@ const routes = {
   },
   post: {
     id: 'blog/post',
-    pattern: '/blog/:pid',
+    patterns: ['/blog/:pid'],
     data: pid => [{
       url: `ustwo/v1/posts/${pid}`,
       type: 'post',
@@ -83,7 +83,7 @@ const routes = {
   },
   legal: {
     id: 'legal',
-    pattern: '/legal',
+    patterns: ['/legal'],
     data: () => [{
       url: 'ustwo/v1/pages/legal',
       type: 'page',
@@ -92,8 +92,8 @@ const routes = {
   },
   joinUs: {
     id: 'join-us',
-    pattern: '/join-us',
-    data: () => [{
+    patterns: ['/join-us', '/join-us/:lid'],
+    data: lid => [{
       url: 'ustwo/v1/pages/join-us',
       type: 'page',
       slug: 'join-us'

--- a/src/app/flux/store.js
+++ b/src/app/flux/store.js
@@ -15,6 +15,7 @@ import Defaults from './defaults';
 
 const _state = Object.assign({
   currentPage: Nulls.page,
+  currentSection: Nulls.section,
   blogCategory: Defaults.blogCategory,
   searchMode: Defaults.searchMode,
   searchQuery: Nulls.searchQuery,
@@ -72,7 +73,7 @@ window._state = _state;
 const Store = Object.assign(
   EventEmitter.prototype,
   {
-    setPage(newPage, statusCode) {
+    setPage(newPage, newSection, statusCode) {
       const newPageIdArray = newPage.split('/');
       const slug = newPageIdArray[newPageIdArray.length - 1];
       if(_state.page && _state.page.slug !== slug) {
@@ -95,6 +96,7 @@ const Store = Object.assign(
         _state.postsPaginationTotal = Nulls.postsPaginationTotal;
       }
       _state.currentPage = newPage;
+      _state.currentSection = newSection || Nulls.section;
       _state.statusCode = statusCode;
       _state.modal = null;
       _state.relatedContent = [];

--- a/src/app/flux/store.js
+++ b/src/app/flux/store.js
@@ -15,7 +15,7 @@ import Defaults from './defaults';
 
 const _state = Object.assign({
   currentPage: Nulls.page,
-  currentSection: Nulls.section,
+  currentHash: Nulls.section,
   blogCategory: Defaults.blogCategory,
   searchMode: Defaults.searchMode,
   searchQuery: Nulls.searchQuery,
@@ -73,7 +73,7 @@ window._state = _state;
 const Store = Object.assign(
   EventEmitter.prototype,
   {
-    setPage(newPage, newSection, statusCode) {
+    setPage(newPage, newParams, newHash, newStatusCode) {
       const newPageIdArray = newPage.split('/');
       const slug = newPageIdArray[newPageIdArray.length - 1];
       if(_state.page && _state.page.slug !== slug) {
@@ -96,8 +96,9 @@ const Store = Object.assign(
         _state.postsPaginationTotal = Nulls.postsPaginationTotal;
       }
       _state.currentPage = newPage;
-      _state.currentSection = newSection || Nulls.section;
-      _state.statusCode = statusCode;
+      _state.currentParams = newParams || Nulls.params;
+      _state.currentHash = newHash || Nulls.hash;
+      _state.statusCode = newStatusCode;
       _state.modal = null;
       _state.relatedContent = [];
       Store.emit('change', _state);

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,9 +2,9 @@
 
 import React from 'react';
 
-import env from './adaptors/server/env';
-import App from './components/app';
-import Flux from './flux';
+import env from 'app/adaptors/server/env';
+import App from 'app/components/app';
+import Flux from 'app/flux';
 
 window.env = env;
 

--- a/src/server/bootstrapper.js
+++ b/src/server/bootstrapper.js
@@ -32,76 +32,108 @@ const globalLoads = [{
   url: 'ustwo/v1/studios?_embed',
   type: 'studios'
 }];
+let _state;
+
+function navigate(urlString) {
+  const vurl = virtualUrl(urlString);
+  const path = vurl.pathname + vurl.search;
+  let route = find(Routes, route => {
+    return some(route.patterns, pattern => RoutePattern.fromString(pattern).matches(path));
+  });
+
+  if (!route) {
+    route = Routes.notfound;
+  }
+  const pattern = find(route.patterns, pattern => RoutePattern.fromString(pattern).matches(path));
+  let paramsResult = RoutePattern.fromString(pattern).match(path);
+  let params = paramsResult ? paramsResult.params : [];
+  let namedParams = paramsResult ? paramsResult.namedParams : [];
+  let action = applyRoute(route.id, namedParams, '', route.data.apply(null, params), route.statusCode);
+
+  switch(route.id) {
+    case 'blog':
+      Flux.setBlogCategoryTo(params[0] || 'all');
+      break;
+    case 'blog/search-results':
+      Flux.setSearchQueryTo(params[0]);
+      break;
+  }
+  return action.then(state => Promise.resolve(state));
+}
+function applyRoute(page, params, hash, itemsToLoad, statusCode) {
+  return Promise.all([
+    setPage(page, params, hash, statusCode || 200),
+    loadData([].concat(globalLoads, itemsToLoad))
+  ]).then(responses => responses[1]);
+}
+function applyData(response, type) {
+  const changeSet = {};
+  changeSet[type] = response.data;
+  if (response.postsPaginationTotal) {
+    changeSet.postsPaginationTotal = parseInt(response.postsPaginationTotal, 10);
+  }
+  Object.assign(_state, changeSet);
+  log('Loaded', type, _state[type]);
+}
+function applySocialMediaDataForPosts(response, type) {
+  const index = findIndex(_state.posts, 'slug', response.slug);
+  if (index > -1) {
+    _state.posts[index][type] = response.data;
+    log(`Added ${type}`, response.data);
+  }
+}
+function setPage(newPage, newParams, newHash, statusCode) {
+  _state.currentPage = newPage;
+  _state.currentParams = newParams;
+  _state.currentHash = newHash;
+  _state.statusCode = statusCode;
+  return Promise.resolve(_state);
+}
+function loadData(itemsToLoad) {
+  return DataLoader(itemsToLoad, applyData).then(() => _state);
+}
+function setBlogCategoryTo(id) {
+  _state.blogCategory = id;
+  _state.postsPagination = Defaults.postsPagination;
+  return Promise.resolve(_state);
+}
+function setSearchQueryTo(string) {
+  _state.searchQuery = string;
+  return Promise.resolve(_state);
+}
+function getSocialSharesForPost() {
+  const hasFacebookData = !!_state.facebookShares || _state.facebookShares === 0;
+  const hasTwitterData = !!_state.twitterShares || _state.twitterShares === 0;
+  let promise;
+  if (hasFacebookData && hasTwitterData) {
+    promise = Promise.resolve(_state);
+  } else {
+    promise = fetchSocialMediaData(_state.post.slug, applyData).then(() => _state);
+  }
+  return promise;
+}
+function getSocialSharesForPosts() {
+  return Promise.all(_state.posts.map(post => {
+    const hasFacebookData = !!post.facebookShares || post.facebookShares === 0;
+    const hasTwitterData = !!post.twitterShares || post.twitterShares === 0;
+    let promise;
+    if (hasFacebookData && hasTwitterData) {
+      promise = Promise.resolve(_state);
+    } else {
+      promise = fetchSocialMediaData(post.slug, applySocialMediaDataForPosts).then(() => _state);
+    }
+    return promise;
+  })).then(() => _state);
+}
 
 function bootstrapper(initialUrl, hostApi, proxyUrl) {
-  const _state = {
+  _state = {
     relatedContent: []
   };
   const vurl = virtualUrl(initialUrl);
   global.hostApi = hostApi;
   global.proxyUrl = proxyUrl;
-
-  if (!RoutePattern.fromString(Routes.home.pattern).matches(vurl.pathname)) {
-    return navigate(vurl.original);
-  } else {
-    return applyRoute(Routes.home.id, undefined, Routes.home.data(), Routes.home.statusCode);
-  }
-  function navigate(urlString) {
-    const vurl = virtualUrl(urlString);
-    const path = vurl.pathname + vurl.search;
-    let route = find(Routes, route => {
-      return RoutePattern.fromString(route.pattern).matches(path);
-    });
-
-    if (!route) {
-      route = Routes.notfound;
-    }
-    let paramsSearch = RoutePattern.fromString(route.pattern).match(path);
-    let params = paramsSearch ? paramsSearch.params : [];
-    let action = applyRoute(route.id, undefined, route.data.apply(null, params), route.statusCode);
-
-    switch(route.id) {
-      case 'blog':
-        setBlogCategoryTo(params[0] || 'all');
-        break;
-      case 'blog/search-results':
-        setSearchQueryTo(params[0]);
-        break;
-    }
-    return action.then(state => Promise.resolve(state));
-  }
-  function applyRoute(page, section, itemsToLoad, statusCode) {
-    return Promise.all([
-      setPage(page, statusCode || 200),
-      loadData([].concat(globalLoads, itemsToLoad))
-    ]).then(responses => responses[1]);
-  }
-  function applyData(response, type) {
-    const changeSet = {};
-    changeSet[type] = response.data;
-    if (response.postsPaginationTotal) {
-      changeSet.postsPaginationTotal = parseInt(response.postsPaginationTotal, 10);
-    }
-    Object.assign(_state, changeSet);
-    log('Loaded', type, _state[type]);
-  }
-  function setPage(newPage, statusCode) {
-    _state.currentPage = newPage;
-    _state.statusCode = statusCode;
-    return Promise.resolve(_state);
-  }
-  function loadData(itemsToLoad) {
-    return DataLoader(itemsToLoad, applyData).then(() => _state);
-  }
-  function setBlogCategoryTo(id) {
-    _state.blogCategory = id;
-    _state.postsPagination = Defaults.postsPagination;
-    return Promise.resolve(_state);
-  }
-  function setSearchQueryTo(string) {
-    _state.searchQuery = string;
-    return Promise.resolve(_state);
-  }
+  return navigate(vurl.original);
 }
 
 export default bootstrapper;

--- a/src/server/bootstrapper.js
+++ b/src/server/bootstrapper.js
@@ -44,7 +44,7 @@ function bootstrapper(initialUrl, hostApi, proxyUrl) {
   if (!RoutePattern.fromString(Routes.home.pattern).matches(vurl.pathname)) {
     return navigate(vurl.original);
   } else {
-    return applyRoute(Routes.home.id, Routes.home.data(), Routes.home.statusCode);
+    return applyRoute(Routes.home.id, undefined, Routes.home.data(), Routes.home.statusCode);
   }
   function navigate(urlString) {
     const vurl = virtualUrl(urlString);
@@ -58,7 +58,7 @@ function bootstrapper(initialUrl, hostApi, proxyUrl) {
     }
     let paramsSearch = RoutePattern.fromString(route.pattern).match(path);
     let params = paramsSearch ? paramsSearch.params : [];
-    let action = applyRoute(route.id, route.data.apply(null, params), route.statusCode);
+    let action = applyRoute(route.id, undefined, route.data.apply(null, params), route.statusCode);
 
     switch(route.id) {
       case 'blog':
@@ -70,9 +70,9 @@ function bootstrapper(initialUrl, hostApi, proxyUrl) {
     }
     return action.then(state => Promise.resolve(state));
   }
-  function applyRoute(name, itemsToLoad, statusCode) {
+  function applyRoute(page, section, itemsToLoad, statusCode) {
     return Promise.all([
-      setPage(name, statusCode || 200),
+      setPage(page, statusCode || 200),
       loadData([].concat(globalLoads, itemsToLoad))
     ]).then(responses => responses[1]);
   }


### PR DESCRIPTION
- Hashes added to the join us url corresponding to the individual studios will open the jobs listing on that tab.
- Removed superfluous direct dom manipulation.
- If a bad hash is entered, defaults to the all jobs listing.

@daaain what do you think?

(Fixes #275)