### PR TITLE
Make `log()` keep quiet on the client, unless `env.verbose` is set to `true` runtime.

### DIFF
--- a/src/app/adaptors/server/window.js
+++ b/src/app/adaptors/server/window.js
@@ -1,3 +1,5 @@
+import env from 'app/adaptors/server/env';
+
 export default {
   location: {
     href: '',
@@ -26,5 +28,6 @@ export default {
   localStorage: {
     getItem: ()=>{},
     setItem: ()=>{}
-  }
+  },
+  env: env
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,11 +2,11 @@
 
 import React from 'react';
 
-import Env from './adaptors/server/env';
+import env from './adaptors/server/env';
 import App from './components/app';
 import Flux from './flux';
 
-window.env = Env;
+window.env = env;
 
 React.initializeTouchEvents(true);
 

--- a/src/app/lib/log.js
+++ b/src/app/lib/log.js
@@ -1,5 +1,6 @@
 import env from 'app/adaptors/server/env';
+import window from 'app/adaptors/server/window';
 
 export default function () {
-  env.verbose && console.log.apply(console, arguments);
+  window.env.verbose && console.log.apply(console, arguments);
 }


### PR DESCRIPTION
@collingo see title, seems to cover all bases (apart from missing the output straight on page load).