### PR TITLE
Make sandbox work again; plus remove unused ES7 class properties flag from Babel.

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -10,4 +10,4 @@ RUN mkdir -p /home/ustwo/public
 
 EXPOSE 8888
 
-CMD ["node", "./node_modules/babel/lib/_babel-node", "--optional", "es7.classProperties", "src/server"]
+CMD ["node", "./node_modules/babel/lib/_babel-node", "src/server"]

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,6 +1,8 @@
 FROM ustwo/nodejs:4.1.1
 MAINTAINER Davide Petrillo <davide@ustwo.com>
 
+ENV NODE_PATH /home/ustwo/src
+
 COPY package.sandbox.json /home/ustwo/package.json
 RUN npm install --production
 COPY src /home/ustwo/src
@@ -8,4 +10,4 @@ RUN mkdir -p /home/ustwo/public
 
 EXPOSE 8889
 
-CMD ["node", "./node_modules/babel/lib/_babel-node", "--optional", "es7.classProperties", "src/server/index.sandbox.js"]
+CMD ["node", "./node_modules/babel/lib/_babel-node", "src/server/index.sandbox.js"]

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ include tasks/*.mk
 ###############################################################################
 
 ## Porcelain ##################################################################
-install: network-create vault-create assets-create app-create proxy-create
-build-all: compiler-build build
+install: network-create vault-create assets-create app-create proxy-create sandbox-create
+build-all: compiler-build sandbox-build build
 vault: vault-save
 build: app-build assets-build
 test: assets-unit-test assets-integration-test

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -10,9 +10,9 @@ upstream frontend {
   server usweb_app:8888;
 }
 
-#upstream sandbox {
-#  server usweb_sandbox:8889;
-#}
+upstream sandbox {
+ server usweb_sandbox:8889;
+}
 
 
 ###############################################################################
@@ -20,7 +20,6 @@ upstream frontend {
 ###############################################################################
 
 # HTTP connection for CDN to source files from
-# TODO: refactor so we're not repeating includes
 server {
   listen 80;
   server_name origin.ustwo.com usweb_proxy;

--- a/etc/nginx/locations/production.conf
+++ b/etc/nginx/locations/production.conf
@@ -7,7 +7,7 @@ include /etc/nginx/locations/sitemap.conf;
 
 include /etc/nginx/locations/spa.conf;
 include /etc/nginx/locations/api.conf;
-#include /etc/nginx/locations/sandbox.conf;
+include /etc/nginx/locations/sandbox.conf;
 
 location @spa {
   proxy_pass http://frontend;

--- a/etc/nginx/locations/staging.conf
+++ b/etc/nginx/locations/staging.conf
@@ -2,7 +2,7 @@ include /etc/nginx/locations/assets.conf;
 include /etc/nginx/locations/sitemap.conf;
 
 include /etc/nginx/locations/spa.conf;
-#include /etc/nginx/locations/sandbox.conf;
+include /etc/nginx/locations/sandbox.conf;
 
 location /api {
   proxy_cache_methods GET;

--- a/src/server/routes.sandbox.js
+++ b/src/server/routes.sandbox.js
@@ -18,9 +18,7 @@ router.get('/:component.js', (req, res, next) => {
 
   let aliasifyConfig = require('app/aliases.sandbox.json');
 
-  b.transform(babelify.configure({
-      optional: ["es7.classProperties"]
-  }));
+  b.transform(babelify);
   b.transform(aliasify, aliasifyConfig);
 
   b.require('react', {expose: 'react'});


### PR DESCRIPTION
@collingo this should make sandbox work with the standard `make && make install`