### PR TITLE
Fix `page-container` extra class omission bug.

### DIFF
--- a/src/app/components/app/index.js
+++ b/src/app/components/app/index.js
@@ -141,7 +141,7 @@ const App = React.createClass({
             takeover={this.showTakeover()}
           />
         </EntranceTransition>
-        <PageContainer key={state.currentPage} className={contentClasses}>
+        <PageContainer key={state.currentPage} extraClasses={contentClasses}>
           <TransitionManager
             component="div"
             className="page-loader-container"

--- a/src/app/components/page-container/index.js
+++ b/src/app/components/page-container/index.js
@@ -3,7 +3,8 @@ import React from 'react';
 const PageContainer = React.createClass({
   render() {
     const { children, transitionState } = this.props;
-    return <div className="page-container">
+    const classNames = 'page-container ' + this.props.extraClasses;
+    return <div className={classNames}>
       {React.Children.map(children, (child) => {
         return React.cloneElement(child, { transitionState: transitionState });
       })}


### PR DESCRIPTION
@phil-linnell seems that `className` on `PageContainer` just overridden the classes inside the component, so now I'm passing these extra classes in via `props` which fixed the issue.