### PR TITLE
Remove min-height on .single-column - fixes #421

### DIFF
--- a/src/app/components/single-column/_index.scss
+++ b/src/app/components/single-column/_index.scss
@@ -85,7 +85,6 @@
     }
 
     &:first-of-type {
-      min-height: 300px;
 
       .title {
         font-size: 40px;
@@ -107,7 +106,6 @@
     }
 
     &:first-of-type {
-      min-height: 400px;
 
       .title {
         font-size: 60px;


### PR DESCRIPTION
@daaain 

Can you merge please - I've removed the min height as it was causing excessive whitespace around short paragraphs. 