### PR TITLE
Adding back code-highlight to blog post, tweaked performance issue with scrolling.

### DIFF
--- a/src/app/components/app/index.js
+++ b/src/app/components/app/index.js
@@ -5,7 +5,7 @@ import React from 'react';
 import Meta from "react-helmet";
 import TransitionManager from 'react-transition-manager';
 import classnames from 'classnames';
-import { get } from 'lodash';
+import { get, throttle } from 'lodash';
 import find from 'lodash/collection/find';
 import includes from 'lodash/collection/includes';
 import Flux from 'app/flux';
@@ -91,7 +91,7 @@ const App = React.createClass({
     this.getViewportDimensions();
 
     /* Get dimensions of viewport to calculate mousePosition and scrollPosition (for example) */
-    window.addEventListener('scroll', this.getDocumentScrollPosition);
+    window.addEventListener('scroll', throttle(() => this.getDocumentScrollPosition(), 240));
     /* Get new dimensions when device orientationchange etc */
     window.addEventListener('resize', this.getViewportDimensions);
 

--- a/src/app/components/post/index.js
+++ b/src/app/components/post/index.js
@@ -20,6 +20,9 @@ import ScrollWrapper from 'app/components/scroll-wrapper';
 
 const PagePost = React.createClass({
   mixins: [getScrollTrackerMixin('post')],
+  shouldComponentUpdate(nextProps, nextState) {
+    return !this.props.loaded;
+  },
   render() {
     const { post, footer, studios, currentPage, documentScrollPosition, viewportDimensions } = this.props;
     const category = get(post, '_embedded.wp:term.0.0', []);

--- a/src/app/lib/module-renderer.js
+++ b/src/app/lib/module-renderer.js
@@ -112,10 +112,7 @@ function renderVideo(moduleData, index, options) {
 }
 
 function renderCode(moduleData, index, options) {
-    var code = get(moduleData, 'attr.body.value').replace(/(?:\r\n|\r|\n)/g, '<br/>').replace(/ /g, '&nbsp;').replace('Button', ' Button ');
-    return (
-        <code className="hljs pf" dangerouslySetInnerHTML={{ __html: code }}></code>
-    );
+    return <CodeHighlighter code={get(moduleData, 'attr.body.value')} key={`logitem-${index}-${Date.now()}`} />
 }
 
 function renderModules(options) {


### PR DESCRIPTION
This PR covers:
1. Adding back code highlighting to blog posts, fixed issue with multiple nesting and multiple re-rendering.
2. Added `throttle` of 240ms to main onScroll event listener to help with performance.

Notes:
* Code highlighting is working but it's trying to detect what language is for each block, as right now there is no way to pass the language. This eventually will need to get implemented for optimal results.