### PR TITLE
Redirect HTTP traffic for ustwo.com and diversity subdomain to HTTPS

### DIFF
--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -29,7 +29,7 @@ server {
 
 server {
   listen 80;
-  server_name www.ustwo.com;
+  server_name ustwo.com www.ustwo.com diversity.ustwo.com;
 
   if ($http_user_agent ~* "libwww") {
     return 403;

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -62,7 +62,9 @@ server {
 
 server {
   listen 443 default ssl;
-  server_name local.ustwo.com origin.ustwo.com;
+  server_name ustwo.com local.ustwo.com origin.ustwo.com;
+
+  add_header Strict-Transport-Security "max-age=31536000";
 
   include /etc/nginx/ssl.conf;
   include /etc/nginx/locations/production.conf;


### PR DESCRIPTION
Hey,

I noticed last night that visiting <http://ustwo.com> doesn't redirect to HTTPS, only <http://www.ustwo.com>. Added a fix for this and I _think_ that this should resolve #559 as well.

My nginx is a bit rusty so would be great if @daaain could take a look at this 😄 